### PR TITLE
Style scrollbars, align edit button, center windows

### DIFF
--- a/oilseals/gui/gui_mm.py
+++ b/oilseals/gui/gui_mm.py
@@ -360,7 +360,20 @@ class InventoryApp(ctk.CTkFrame):
             self.tree.column(col, anchor="center", width=120)
 
         # Add scrollbar
-        tree_scrollbar = ttk.Scrollbar(parent, orient="vertical", command=self.tree.yview)
+        # Style the scrollbar to match the clean look used on the home page
+        sb_style = ttk.Style()
+        sb_style.theme_use("clam")
+        sb_style.configure(
+            "Clean.Vertical.TScrollbar",
+            background="#D00000",
+            troughcolor="#111827",
+            bordercolor="#111827",
+            lightcolor="#D00000",
+            darkcolor="#B71C1C",
+            arrowcolor="#FFFFFF"
+        )
+
+        tree_scrollbar = ttk.Scrollbar(parent, orient="vertical", command=self.tree.yview, style="Clean.Vertical.TScrollbar")
         self.tree.configure(yscrollcommand=tree_scrollbar.set)
         self.tree.pack(side="left", fill="both", expand=True)
         tree_scrollbar.pack(side="right", fill="y")

--- a/oilseals/gui/gui_transaction_window.py
+++ b/oilseals/gui/gui_transaction_window.py
@@ -258,7 +258,8 @@ class TransactionWindow(ctk.CTkFrame):
 
     def _create_edit_section(self, parent):
         edit_frame = ctk.CTkFrame(parent, fg_color="transparent")
-        edit_frame.grid(row=0, column=2, sticky="e")
+        # Align vertically with the text fields by adding matching top padding
+        edit_frame.grid(row=0, column=2, sticky="e", pady=(30, 0))
 
         self.edit_btn = ctk.CTkButton(
             edit_frame, 
@@ -272,7 +273,8 @@ class TransactionWindow(ctk.CTkFrame):
             height=40, 
             command=self.toggle_edit_mode
         )
-        self.edit_btn.pack()
+        # Nudge the button down slightly to align with adjacent entry fields
+        self.edit_btn.pack(pady=(5, 0))
 
         self.save_status_label = ctk.CTkLabel(
             edit_frame, 
@@ -343,7 +345,19 @@ class TransactionWindow(ctk.CTkFrame):
             self.tree.heading(col, text=config["text"])
             self.tree.column(col, anchor=config["anchor"], width=config["width"])
 
-        tree_scrollbar = ttk.Scrollbar(parent, orient="vertical", command=self.tree.yview)
+        # Styled scrollbar to match clean, elegant look
+        sb_style = ttk.Style()
+        sb_style.theme_use("clam")
+        sb_style.configure(
+            "Clean.Vertical.TScrollbar",
+            background="#D00000",
+            troughcolor="#111827",
+            bordercolor="#111827",
+            lightcolor="#D00000",
+            darkcolor="#B71C1C",
+            arrowcolor="#FFFFFF"
+        )
+        tree_scrollbar = ttk.Scrollbar(parent, orient="vertical", command=self.tree.yview, style="Clean.Vertical.TScrollbar")
         self.tree.configure(yscrollcommand=tree_scrollbar.set)
         self.tree.pack(side="left", fill="both", expand=True)
         tree_scrollbar.pack(side="right", fill="y")
@@ -461,6 +475,17 @@ class TransactionWindow(ctk.CTkFrame):
         settings.configure(fg_color="#000000")
         settings.transient(self)
         settings.grab_set()
+        # Center the window on the screen
+        try:
+            settings.update_idletasks()
+            screen_width = settings.winfo_screenwidth()
+            screen_height = settings.winfo_screenheight()
+            win_w, win_h = 400, 300
+            x = (screen_width - win_w) // 2
+            y = (screen_height - win_h) // 2
+            settings.geometry(f"{win_w}x{win_h}+{x}+{y}")
+        except Exception:
+            pass
         return settings
 
     def _populate_settings_form(self, settings_window):

--- a/oilseals/gui/gui_transactions.py
+++ b/oilseals/gui/gui_transactions.py
@@ -225,7 +225,19 @@ class TransactionTab:
             self.tran_tree.heading(col, text=header, command=lambda c=col: self.sort_by_column(c))
             self.tran_tree.column(col, **column_config[col])
 
-        scrollbar = ttk.Scrollbar(inner_table, orient="vertical", command=self.tran_tree.yview)
+        # Styled scrollbar to match the clean look
+        sb_style = ttk.Style()
+        sb_style.theme_use("clam")
+        sb_style.configure(
+            "Clean.Vertical.TScrollbar",
+            background="#D00000",
+            troughcolor="#111827",
+            bordercolor="#111827",
+            lightcolor="#D00000",
+            darkcolor="#B71C1C",
+            arrowcolor="#FFFFFF"
+        )
+        scrollbar = ttk.Scrollbar(inner_table, orient="vertical", command=self.tran_tree.yview, style="Clean.Vertical.TScrollbar")
         self.tran_tree.configure(yscrollcommand=scrollbar.set)
         self.tran_tree.pack(side="left", fill="both", expand=True)
         scrollbar.pack(side="right", fill="y")


### PR DESCRIPTION
Apply consistent scrollbar styling, align the Edit button, and center the threshold window to improve UI consistency and user experience.

The scrollbar styling was updated to match the clean look established in `gui_home_page.py`. The Edit button's vertical alignment was adjusted to perfectly match the adjacent text fields. The threshold settings window now opens centered on the screen for better usability.

---
<a href="https://cursor.com/background-agent?bcId=bc-283ae32e-a9d1-48da-95c3-9cbc0ee3b425">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-283ae32e-a9d1-48da-95c3-9cbc0ee3b425">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

