### PR TITLE
Fix admin panel window display and behavior

### DIFF
--- a/oilseals/gui/gui_products.py
+++ b/oilseals/gui/gui_products.py
@@ -18,22 +18,23 @@ class AdminPanel:
         # Create CustomTkinter window
         self.win = ctk.CTkToplevel(parent)
         self.win.withdraw()
-
-        # Remove window manager decorations (prevents flash resize)
-        self.win.overrideredirect(True)
-
-        # Set directly to full screen size
-        screen_w = self.win.winfo_screenwidth()
-        screen_h = self.win.winfo_screenheight()
-        self.win.geometry(f"{screen_w}x{screen_h}+0+0")
-
-        # Reapply titlebar AFTER it's full screen (optional)
-        self.win.overrideredirect(False)
         self.win.title("Manage Database")
         self.win.configure(fg_color=theme.get("bg"))  # Set window background to theme
 
-        # Now show without resize flash
+        # Apply desired default window state: windowed fullscreen (maximized properly)
+        self._apply_initial_maximized_state()
+
+        # Show window
         self.win.deiconify()
+
+        # Configure minimum usable size to avoid too-small layouts
+        try:
+            self.win.minsize(1000, 700)
+        except Exception:
+            pass
+
+        # Bind to minimize/unmap to implement custom shrink-and-center behavior
+        self.win.bind("<Unmap>", self._on_unmap_minimize)
 
         # Create main container with dynamic background
         self.main_container = ctk.CTkFrame(self.win, fg_color=theme.get("bg"))
@@ -47,6 +48,80 @@ class AdminPanel:
 
         # Subscribe to theme changes to update colors dynamically
         theme.subscribe(self.update_colors)
+
+
+    def _apply_initial_maximized_state(self):
+        """Maximize using the window manager to avoid geometry/titlebar mismatches.
+
+        Tries native 'zoomed' state first, then falls back to the WM-reported
+        maximum size to emulate a proper windowed-fullscreen without cutting off
+        content when toggling maximize.
+        """
+        try:
+            # Request maximize via WM
+            self.win.update_idletasks()
+            self.win.state("zoomed")
+
+            # Validate maximize took effect; if not, fall back
+            self.win.update_idletasks()
+            max_w, max_h = self.win.wm_maxsize()
+            cur_w = self.win.winfo_width()
+            cur_h = self.win.winfo_height()
+            if cur_w <= 1 or cur_h <= 1:
+                # Window not yet realized; compute after another update
+                self.win.update()
+                cur_w = self.win.winfo_width()
+                cur_h = self.win.winfo_height()
+
+            # If not close to WM max size, apply fallback geometry
+            if max_w and max_h and (abs(cur_w - max_w) > 10 or abs(cur_h - max_h) > 10):
+                self.win.geometry(f"{max_w}x{max_h}+0+0")
+        except Exception:
+            # Fallback purely to wm_maxsize if zoomed is unsupported
+            try:
+                max_w, max_h = self.win.wm_maxsize()
+                if max_w and max_h:
+                    self.win.geometry(f"{max_w}x{max_h}+0+0")
+                else:
+                    # Last-resort: use screen size
+                    screen_w = self.win.winfo_screenwidth()
+                    screen_h = self.win.winfo_screenheight()
+                    self.win.geometry(f"{screen_w}x{screen_h}+0+0")
+            except Exception:
+                pass
+
+
+    def _on_unmap_minimize(self, event):
+        """When the window is minimized/iconified, shrink and center instead of hiding."""
+        try:
+            # Only intercept actual minimize/iconify actions
+            if self.win.state() == "iconic":
+                # Deiconify and switch to normal state
+                self.win.after(1, self._shrink_and_center)
+        except Exception:
+            pass
+
+
+    def _shrink_and_center(self):
+        """Resize to a smaller, centered window that remains visible."""
+        try:
+            self.win.deiconify()
+            self.win.state("normal")
+            self.win.update_idletasks()
+
+            screen_w = self.win.winfo_screenwidth()
+            screen_h = self.win.winfo_screenheight()
+
+            # Reasonable smaller size (not too small)
+            target_w = max(int(screen_w * 0.7), 1000)
+            target_h = max(int(screen_h * 0.7), 700)
+
+            pos_x = max((screen_w - target_w) // 2, 0)
+            pos_y = max((screen_h - target_h) // 2, 0)
+
+            self.win.geometry(f"{target_w}x{target_h}+{pos_x}+{pos_y}")
+        except Exception:
+            pass
 
 
     def create_tab_system(self, parent):


### PR DESCRIPTION
Implement proper windowed fullscreen for the Admin Panel and change minimize behavior to shrink and center.

The previous implementation used `overrideredirect(True)` and manual geometry for fullscreen, which interfered with the window manager's understanding of the window state. This caused the maximize button to appear even when 'fullscreen' and resulted in content cutoff upon clicking it. The fix leverages native window manager maximize (`state("zoomed")`) and provides robust fallbacks to ensure correct windowed fullscreen behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad42330a-f0ec-47ea-b719-0464424afab0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ad42330a-f0ec-47ea-b719-0464424afab0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

